### PR TITLE
Standard for Injacted web3 Provider

### DIFF
--- a/CIPs/0022.md
+++ b/CIPs/0022.md
@@ -1,0 +1,21 @@
+# CIP [0022]: Standard for Injacted web3 Provider
+
+- Date: 2020-10-29
+- Author: @daoauth @NAKsir-melody
+- Status: DRAFT
+
+## Overview
+- Standard to find out the type of web3 provider to support dapps running in web browsers
+
+## Goals
+- In the case of web DApps, you can only use [DSRV Celo Extension Wallet](https://chrome.google.com/webstore/detail/celo-desktop-wallet/kkilomkmpmkbdnfelcpgckmpcaemjcdh) or MetaMask Extension wallet, but a standard is required to distinguish them.
+- Through these standards, each provider can be identified and transactions can be sent to the Celo blockchain through appropriate operations.
+
+## Proposed Solution
+- Ready `ethereum.isMetaMask` property for MetaMask. Through this property, it can be seen that it is a provider injected in MetaMask.
+- So, it is suggested that providers injected in Celo have a property with the syntax of `celo[providerName]`.
+  * eg. Some injected provider has `celo.isExtWallet` property. It's injected by DSRV Celo Extension wallet
+  * eg. For DApp browser has `celo.isDexFair` too
+
+## Useful Links
+- [MetaMask](https://docs.metamask.io/guide/ethereum-provider.html#properties)


### PR DESCRIPTION
## Overview
- Standard to find out the type of web3 provider to support dapps running in web browsers

## Goals
- In the case of web DApps, you can only use [DSRV Celo Extension Wallet](https://chrome.google.com/webstore/detail/celo-desktop-wallet/kkilomkmpmkbdnfelcpgckmpcaemjcdh) or MetaMask Extension wallet, but a standard is required to distinguish them.
- Through these standards, each provider can be identified and transactions can be sent to the Celo blockchain through appropriate operations.

## Proposed Solution
- Ready `ethereum.isMetaMask` property for MetaMask. Through this property, it can be seen that it is a provider injected in MetaMask.
- So, it is suggested that providers injected in Celo have a property with the syntax of `celo[providerName]`.
  * eg. Some injected provider has `celo.isExtWallet` property. It's injected by DSRV Celo Extension wallet
  * eg. For DApp browser has `celo.isDexFair` too

## Useful Links
- [MetaMask](https://docs.metamask.io/guide/ethereum-provider.html#properties)